### PR TITLE
Newlines are not valid in JSON strings

### DIFF
--- a/SlackNotifications/SlackNotificationsCore.php
+++ b/SlackNotifications/SlackNotificationsCore.php
@@ -58,7 +58,7 @@ class SlackNotifications
 			{
 				$out .= ")";
 			}
-			return $out."\n";
+			return $out."\\n";
 		}
 		else
 		{


### PR DESCRIPTION
`getSlackArticleText()` puts a literal (unscaped) newline character in the middle of a JSON string. This causes the JSON payload to fail to parse by standards-compliant parsers. (Slack may be more lax than JavaScript's `JSON.parse()` is.)

This patch properly escapes the newline as `\n`.